### PR TITLE
README update  for codestar-notification service linked role

### DIFF
--- a/examples/backend-service/README.md
+++ b/examples/backend-service/README.md
@@ -4,7 +4,19 @@ This solution blueprint creates a backend servie that **does not** sit behind a 
 
 * Deploy the [core-infra](../core-infra/README.md). Note if you have already deployed the infra then you can reuse it as well.
 * In this folder, copy the `terraform.tfvars.example` file to `terraform.tfvars` and update the variables.
-* Deploy the terraform templates in this repository using `terraform apply`.
+* **NOTE:** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
+  * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
+
+    ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
+  *  If you receive the error above, please create the service-linked role with the `aws cli` below.
+  * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
+  * Again, once this is created, you will not have to complete these steps for the other examples. 
+* Now you can deploy this blueprint
+```shell
+terraform init
+terraform plan
+terraform apply -auto-approve
+```
 * To test the backend service access using service discovery, deploy the [lb-service](../lb-service/README.md) along with providing the name of this backend service.
 
 <p align="center">

--- a/examples/backend-service/README.md
+++ b/examples/backend-service/README.md
@@ -10,7 +10,7 @@ This solution blueprint creates a backend servie that **does not** sit behind a 
     ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
-  * Again, once this is created, you will not have to complete these steps for the other examples. 
+  * Again, once this is created, you will not have to complete these steps for the other examples.
 * Now you can deploy this blueprint
 ```shell
 terraform init

--- a/examples/blue-green-deployment/README.md
+++ b/examples/blue-green-deployment/README.md
@@ -35,7 +35,6 @@ The AWS resources created by the script are detailed bellow:
     - 1 S3 Bucket (used to store assets accessible from within the application)
     - 1 Dynamodb table (used by the application)
 - ECS Infrastructure
-    - 1 ECS Cluster
     - 2 ECS Services
     - 2 Task definitions
     - IAM roles
@@ -99,22 +98,30 @@ aws secretsmanager create-secret \
     --secret-string "ghp_XXXXXXXXXXXXXXXXXXXXXXXXX"
 ```
 
-**4.** Run Terraform init to download the providers and install the modules
+**4.** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
+  * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
+
+    ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
+  *  If you receive the error above, please create the service-linked role with the `aws cli` below.
+  * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
+  * Again, once this is created, you will not have to complete these steps for the other examples. 
+  
+**5.** Run Terraform init to download the providers and install the modules
 
 ```shell
 terraform init
 ```
 
-**5.** Review the terraform plan output, take a look at the changes that terraform will execute, and then apply them:
+**6.** Review the terraform plan output, take a look at the changes that terraform will execute, and then apply them:
 
 ```shell
 terraform plan
 terraform apply
 ```
 
-**6.** Once Terraform finishes the deployment open the AWS Management Console and go to the AWS CodePipeline service. You will see that the pipeline, which was created by this Terraform code, is in progress. Add some files and Dynamodb items as mentioned [here](#client-considerations-due-to-demo-proposals). Once the pipeline finished successfully and the before assets were added, go back to the console where Terraform was executed, copy the *application_url* value from the output and open it in a browser.
+**7.** Once Terraform finishes the deployment open the AWS Management Console and go to the AWS CodePipeline service. You will see that the pipeline, which was created by this Terraform code, is in progress. Add some files and Dynamodb items as mentioned [here](#client-considerations-due-to-demo-proposals). Once the pipeline finished successfully and the before assets were added, go back to the console where Terraform was executed, copy the *application_url* value from the output and open it in a browser.
 
-**7.** In order to access the also implemented Swagger endpoint copy the *swagger_endpoint* value from the Terraform output and open it in a browser.
+**8.** In order to access the also implemented Swagger endpoint copy the *swagger_endpoint* value from the Terraform output and open it in a browser.
 
 ### Notifications
 

--- a/examples/blue-green-deployment/README.md
+++ b/examples/blue-green-deployment/README.md
@@ -104,8 +104,8 @@ aws secretsmanager create-secret \
     ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
-  * Again, once this is created, you will not have to complete these steps for the other examples. 
-  
+  * Again, once this is created, you will not have to complete these steps for the other examples.
+
 **5.** Run Terraform init to download the providers and install the modules
 
 ```shell

--- a/examples/lb-service/README.md
+++ b/examples/lb-service/README.md
@@ -11,7 +11,12 @@ This solution blueprint creates a web-facing load balanced ECS service. There ar
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
   * Again, once this is created, you will not have to complete these steps for the other examples.  
-* Deploy the terraform templates in this repository using `terraform init` and `terraform apply`
+* Now you can deploy this blueprint
+```shell
+terraform init
+terraform plan
+terraform apply -auto-approve
+```
 
 <p align="center">
   <img src="../../docs/lb-service.png"/>

--- a/examples/lb-service/README.md
+++ b/examples/lb-service/README.md
@@ -7,9 +7,7 @@ This solution blueprint creates a web-facing load balanced ECS service. There ar
 * **NOTE:** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
   * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
 
-    ```shell
-    An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.
-    ```
+    ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
   * Again, once this is created, you will not have to complete these steps for the other examples.  

--- a/examples/lb-service/README.md
+++ b/examples/lb-service/README.md
@@ -4,7 +4,16 @@ This solution blueprint creates a web-facing load balanced ECS service. There ar
 
 * Deploy the [core-infra](../core-infra/README.md). Note if you have already deployed the infra then you can reuse it as well.
 * In this folder, copy the `terraform.tfvars.example` file to `terraform.tfvars` and update the variables.
-* Deploy the terraform templates in this repository using `terraform apply`
+* **NOTE:** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
+  * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
+
+    ```shell
+    An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.
+    ```
+  *  If you receive the error above, please create the service-linked role with the `aws cli` below.
+  * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
+  * Again, once this is created, you will not have to complete these steps for the other examples.  
+* Deploy the terraform templates in this repository using `terraform init` and `terraform apply`
 
 <p align="center">
   <img src="../../docs/lb-service.png"/>

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -9,6 +9,13 @@ Follow the [AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-get
 ### Getting Started
 * Deploy the [core-infra](../core-infra/README.md). Note if you have already deployed the infra then you can reuse it as well.
 * In this folder, copy the `terraform.tfvars.example` file to `terraform.tfvars` and update the variables.
+* **NOTE:** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
+  * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
+
+    ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
+  *  If you receive the error above, please create the service-linked role with the `aws cli` below.
+  * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
+  * Again, once this is created, you will not have to complete these steps for the other examples. 
 * From the previously created AMP workspace, copy the remote-write endpoint. It will have this form, `https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write`.
 * Open the `ecs-adot-config.yaml` in this folder, and change the `AMP_REMOTE_WRITE_ENDPOINT` with above URL and change the REGION to region of AMP workspace.
 * Now you can deploy this blueprint

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -15,7 +15,7 @@ Follow the [AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-get
     ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
-  * Again, once this is created, you will not have to complete these steps for the other examples. 
+  * Again, once this is created, you will not have to complete these steps for the other examples.
 * From the previously created AMP workspace, copy the remote-write endpoint. It will have this form, `https://aps-workspaces.<region>.amazonaws.com/workspaces/<workspace-id>/api/v1/remote_write`.
 * Open the `ecs-adot-config.yaml` in this folder, and change the `AMP_REMOTE_WRITE_ENDPOINT` with above URL and change the REGION to region of AMP workspace.
 * Now you can deploy this blueprint

--- a/examples/rolling-deployment/README.md
+++ b/examples/rolling-deployment/README.md
@@ -105,7 +105,7 @@ aws secretsmanager create-secret \
     ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
   *  If you receive the error above, please create the service-linked role with the `aws cli` below.
   * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
-  * Again, once this is created, you will not have to complete these steps for the other examples. 
+  * Again, once this is created, you will not have to complete these steps for the other examples.
 
 **5.** Run Terraform init to download the providers and install the modules
 

--- a/examples/rolling-deployment/README.md
+++ b/examples/rolling-deployment/README.md
@@ -99,20 +99,28 @@ aws secretsmanager create-secret \
     --secret-string "ghp_XXXXXXXXXXXXXXXXXXXXXXXXX"
 ```
 
-**4.** Run Terraform init to download the providers and install the modules
+**4.** Codestar notification rules require a **one-time** creation of a service-linked role. Please verify one exists or create the codestar-notification service-linked role.
+  * `aws iam get-role --role-name AWSServiceRoleForCodeStarNotifications`
+
+    ```An error occurred (NoSuchEntity) when calling the GetRole operation: The role with name AWSServiceRoleForCodeStarNotifications cannot be found.```
+  *  If you receive the error above, please create the service-linked role with the `aws cli` below.
+  * `aws iam create-service-linked-role --aws-service-name codestar-notifications.amazonaws.com`
+  * Again, once this is created, you will not have to complete these steps for the other examples. 
+
+**5.** Run Terraform init to download the providers and install the modules
 
 ```shell
 terraform init
 ```
 
-**5.** Review the terraform plan output, take a look at the changes that terraform will execute, and then apply them:
+**6.** Review the terraform plan output, take a look at the changes that terraform will execute, and then apply them:
 
 ```shell
 terraform plan
 terraform apply
 ```
 
-**6.** Once Terraform finishes the deployment open the AWS Management Console and go to the AWS CodePipeline service. You will see that the pipeline, which was created by this Terraform code, is in progress. Add some files and Dynamodb items as mentioned [here](#client-considerations-due-to-demo-proposals). Once the pipeline finished successfully and the before assets were added, go back to the console where Terraform was executed, copy the _application_url_ value from the output and open it in a browser.
+**7.** Once Terraform finishes the deployment open the AWS Management Console and go to the AWS CodePipeline service. You will see that the pipeline, which was created by this Terraform code, is in progress. Add some files and Dynamodb items as mentioned [here](#client-considerations-due-to-demo-proposals). Once the pipeline finished successfully and the before assets were added, go back to the console where Terraform was executed, copy the _application_url_ value from the output and open it in a browser.
 
 
 ### Notifications


### PR DESCRIPTION
## Description
Updated example docs to prevent service-linked role creation failures for one-time creation.

``` bash
│ Error: error creating codestar notification rule: ConfigurationException: AWS CodeStar Notifications could not create the AWS CloudWatch Events managed rule in your AWS account. If this is your first time creating a notification rule, the service-linked role for AWS CodeStar Notifications might not yet exist. Creation of this role might take up to 15 minutes. Until it exists, notification rule creation will fail. Wait 15 minutes, and then try again. If this is is not the first time you are creating a notification rule, there might be a problem with a network connection, or one or more AWS services might be experiencing issues. Verify your network connection and check to see if there are any issues with AWS services in your AWS Region before trying again.
│ 
│   with module.codepipeline_ci_cd.aws_codestarnotifications_notification_rule.this,
│   on ../../modules/codepipeline/main.tf line 76, in resource "aws_codestarnotifications_notification_rule" "this":
│   76: resource "aws_codestarnotifications_notification_rule" "this" {
```
## Motivation and Context
Prevent `terraform apply` errors with examples.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
