### PR TITLE
fixed ecs_cluster_id for auto-scaling

### DIFF
--- a/examples/backend-service/main.tf
+++ b/examples/backend-service/main.tf
@@ -116,7 +116,7 @@ module "ecs_service_definition" {
 
   name                       = local.name
   desired_count              = var.desired_count
-  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.cluster_name
   cp_strategy_base           = var.cp_strategy_base
   cp_strategy_fg_weight      = var.cp_strategy_fg_weight
   cp_strategy_fg_spot_weight = var.cp_strategy_fg_spot_weight

--- a/examples/blue-green-deployment/main.tf
+++ b/examples/blue-green-deployment/main.tf
@@ -331,7 +331,7 @@ module "ecs_service_server" {
 
   name           = "${local.name}-server"
   desired_count  = 1
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
 
   security_groups = [module.server_task_security_group.security_group_id]
   subnets         = data.aws_subnets.private.ids
@@ -365,7 +365,7 @@ module "ecs_service_client" {
 
   name           = "${local.name}-client"
   desired_count  = 1
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
 
   security_groups = [module.client_task_security_group.security_group_id]
   subnets         = data.aws_subnets.private.ids

--- a/examples/graviton/main.tf
+++ b/examples/graviton/main.tf
@@ -239,7 +239,7 @@ module "ecs_service_definition_amd64" {
 
   name           = local.name
   desired_count  = var.desired_count
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
   # cp_strategy_base           = var.cp_strategy_base
   # cp_strategy_fg_weight      = var.cp_strategy_fg_weight
   # cp_strategy_fg_spot_weight = var.cp_strategy_fg_spot_weight
@@ -275,7 +275,7 @@ module "ecs_service_definition_arm64" {
 
   name           = "${local.name}-arm"
   desired_count  = var.desired_count
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
   # cp_strategy_base           = var.cp_strategy_base
   # cp_strategy_fg_weight      = var.cp_strategy_fg_weight
   # cp_strategy_fg_spot_weight = var.cp_strategy_fg_spot_weight

--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -183,7 +183,7 @@ module "ecs_service_definition" {
 
   name                       = local.name
   desired_count              = var.desired_count
-  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.cluster_name
   cp_strategy_base           = var.cp_strategy_base
   cp_strategy_fg_weight      = var.cp_strategy_fg_weight
   cp_strategy_fg_spot_weight = var.cp_strategy_fg_spot_weight

--- a/examples/prometheus/main.tf
+++ b/examples/prometheus/main.tf
@@ -100,7 +100,7 @@ module "ecs_service_definition" {
 
   name                       = local.name
   desired_count              = var.desired_count
-  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id             = data.aws_ecs_cluster.core_infra.cluster_name
   cp_strategy_base           = var.cp_strategy_base
   cp_strategy_fg_weight      = var.cp_strategy_fg_weight
   cp_strategy_fg_spot_weight = var.cp_strategy_fg_spot_weight

--- a/examples/rolling-deployment/main.tf
+++ b/examples/rolling-deployment/main.tf
@@ -289,7 +289,7 @@ module "ecs_service_server" {
 
   name           = "${local.name}-server"
   desired_count  = 1
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
 
   security_groups = [module.server_task_security_group.security_group_id]
   subnets         = data.aws_subnets.private.ids
@@ -323,7 +323,7 @@ module "ecs_service_client" {
 
   name           = "${local.name}-client"
   desired_count  = 1
-  ecs_cluster_id = data.aws_ecs_cluster.core_infra.arn
+  ecs_cluster_id = data.aws_ecs_cluster.core_infra.cluster_name
 
   security_groups = [module.client_task_security_group.security_group_id]
   subnets         = data.aws_subnets.private.ids


### PR DESCRIPTION
## Description
Updated the `ecs_cluster_id` with the `cluster_name` vs `arn`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This was preventing auto-scaling policies to attach the ECS service. 
## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
