### PR TITLE
ecs-service scheduled scaling

### DIFF
--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -122,6 +122,7 @@ module "service_alb" {
   tags = local.tags
 }
 
+/*
 module "container_image_ecr" {
   source  = "terraform-aws-modules/ecr/aws"
   version = "~> 1.4"
@@ -135,6 +136,7 @@ module "container_image_ecr" {
 
   tags = local.tags
 }
+*/
 
 module "service_task_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
@@ -213,6 +215,7 @@ module "ecs_service_definition" {
 
   tags = local.tags
 }
+
 
 ################################################################################
 # CodePipeline and CodeBuild for CI/CD

--- a/examples/lb-service/main.tf
+++ b/examples/lb-service/main.tf
@@ -122,7 +122,6 @@ module "service_alb" {
   tags = local.tags
 }
 
-/*
 module "container_image_ecr" {
   source  = "terraform-aws-modules/ecr/aws"
   version = "~> 1.4"
@@ -136,7 +135,6 @@ module "container_image_ecr" {
 
   tags = local.tags
 }
-*/
 
 module "service_task_security_group" {
   source  = "terraform-aws-modules/security-group/aws"

--- a/modules/ecs-service/main.tf
+++ b/modules/ecs-service/main.tf
@@ -184,7 +184,7 @@ resource "aws_iam_role_policy" "task" {
 
 # ------- AWS Autoscaling target to linke the ECS cluster and service -------
 resource "aws_appautoscaling_target" "this" {
-  count = var.enable_autoscaling ? 1 : 0
+  count = var.enable_autoscaling || var.enable_scheduled_autoscaling ? 1 : 0
 
   min_capacity       = var.autoscaling_min_capacity
   max_capacity       = var.autoscaling_max_capacity
@@ -279,5 +279,41 @@ resource "aws_cloudwatch_metric_alarm" "high_cpu_policy_alarm" {
   dimensions = {
     "ServiceName" = aws_ecs_service.this.name
     "ClusterName" = var.ecs_cluster_id
+  }
+}
+
+
+# Scheduled Scaling
+# Schedule scaling is not shown in AWS console. Can view from this cli command - aws application-autoscaling describe-scheduled-actions --service-namespace ecs
+
+resource "aws_appautoscaling_scheduled_action" "scale_up" {
+  count = var.enable_scheduled_autoscaling ? 1 : 0
+
+  name               = "ecs_scheduled_scale_up_${aws_ecs_service.this.name}"
+  resource_id        = aws_appautoscaling_target.this[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this[0].service_namespace
+  schedule           = var.scheduled_autoscaling_up_time
+  timezone           = var.scheduled_autoscaling_timezone
+
+  scalable_target_action {
+    min_capacity = var.scheduled_autoscaling_up__min_capacity
+    max_capacity = var.scheduled_autoscaling_up__max_capacity
+  }
+}
+
+resource "aws_appautoscaling_scheduled_action" "scale_down" {
+  count = var.enable_scheduled_autoscaling ? 1 : 0
+
+  name               = "ecs_scheduled_scale_down_${aws_ecs_service.this.name}"
+  resource_id        = aws_appautoscaling_target.this[0].resource_id
+  scalable_dimension = aws_appautoscaling_target.this[0].scalable_dimension
+  service_namespace  = aws_appautoscaling_target.this[0].service_namespace
+  schedule           = var.scheduled_autoscaling_down_time
+  timezone           = var.scheduled_autoscaling_timezone
+
+  scalable_target_action {
+    min_capacity = var.autoscaling_min_capacity
+    max_capacity = var.autoscaling_max_capacity
   }
 }

--- a/modules/ecs-service/variables.tf
+++ b/modules/ecs-service/variables.tf
@@ -206,6 +206,7 @@ variable "task_cpu_architecture" {
 # Autoscaling
 ################################################################################
 
+#Target Scaling
 variable "enable_autoscaling" {
   description = "Determines whether autoscaling is enabled for the service"
   type        = bool
@@ -234,4 +235,41 @@ variable "autoscaling_cpu_threshold" {
   description = "The desired threashold for CPU consumption"
   type        = number
   default     = 75
+}
+
+# schedule scaling
+variable "enable_scheduled_autoscaling" {
+  description = "Determines whether scheduled autoscaling is enabled for the service"
+  type        = bool
+  default     = true
+}
+
+variable "scheduled_autoscaling_timezone" {
+  description = "Timezone which scheduled scaling occurs"
+  type        = string
+  default     = "America/Los_Angeles"
+}
+
+variable "scheduled_autoscaling_up_time" {
+  description = "Timezone which scheduled scaling occurs"
+  type        = string
+  default     = "cron(0 6 * * ? *)"
+}
+
+variable "scheduled_autoscaling_down_time" {
+  description = "Timezone which scheduled scaling occurs"
+  type        = string
+  default     = "cron(0 20 * * ? *)"
+}
+
+variable "scheduled_autoscaling_up__min_capacity" {
+  description = "The minimum number of tasks to provision"
+  type        = number
+  default     = 4
+}
+
+variable "scheduled_autoscaling_up__max_capacity" {
+  description = "The maximum number of tasks to provision"
+  type        = number
+  default     = 6
 }


### PR DESCRIPTION
## Description
I have added scheduled scaling to modules/ecs-service. This change will scale up based on a cron expression to increase the amount of tasks and another cron expression to scale back down. This will work along side target based scaling or standalone. 

## Motivation and Context
Customers may want examples of other types of scaling ECS / Fargate has to offer. Scheduled scaling allows customers to increased the desired count of tasks during certain parts of the day then scale back down when needed. 

## How Has This Been Tested?
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
