### PR TITLE
Adot fix

### DIFF
--- a/examples/prometheus/ecs-adot-config.yaml
+++ b/examples/prometheus/ecs-adot-config.yaml
@@ -7,7 +7,7 @@ receivers:
       scrape_configs:
       - job_name: "test-prometheus-sample-app"
         static_configs:
-        - targets: [ $PROMETHEUS_SAMPLE_APP ]
+        - targets: [ 0.0.0.0:8080 ]
   awsecscontainermetrics:
     collection_interval: 20s
 
@@ -27,11 +27,10 @@ processors:
           - ecs.task.storage.write_bytes
 
 exporters:
-  awsprometheusremotewrite:
+  prometheusremotewrite:
     endpoint: "AMP_WORKSPACE_REMOTE_WRITE_ENDPOINT"
-    aws_auth:
-      region: "AMP_WORKSPACE_REGION"
-      service: "aps"
+    auth:
+      authenticator: sigv4auth
   logging:
     loglevel: debug
 extensions:
@@ -40,14 +39,16 @@ extensions:
     endpoint: :1888
   zpages:
     endpoint: :55679
+  sigv4auth:
+    region: "AMP_WORKSPACE_REGION"
 
 service:
-  extensions: [pprof, zpages, health_check]
+  extensions: [pprof, zpages, health_check, sigv4auth]
   pipelines:
     metrics:
       receivers: [prometheus]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]
     metrics/ecs:
       receivers: [awsecscontainermetrics]
       processors: [filter]
-      exporters: [logging, awsprometheusremotewrite]
+      exporters: [logging, prometheusremotewrite]

--- a/examples/prometheus/ecs-adot-config.yaml
+++ b/examples/prometheus/ecs-adot-config.yaml
@@ -7,7 +7,7 @@ receivers:
       scrape_configs:
       - job_name: "test-prometheus-sample-app"
         static_configs:
-        - targets: [ 0.0.0.0:8080 ]
+        - targets: [ $PROMETHEUS_SAMPLE_APP ]
   awsecscontainermetrics:
     collection_interval: 20s
 

--- a/examples/prometheus/terraform.tfvars.example
+++ b/examples/prometheus/terraform.tfvars.example
@@ -21,7 +21,7 @@ adot_config_ssm_parameter = "otel-collector-config"
 sidecar_container_definitions = [
   {
     container_name  = "aws-otel-collector",
-    container_image = "public.ecr.aws/aws-observability/aws-otel-collector:latest",
+    container_image = "public.ecr.aws/aws-observability/aws-otel-collector:v0.21.1",
     map_secrets     = { "AOT_CONFIG_CONTENT" : "otel-collector-config" },
     map_environment = { "PROMETHEUS_SAMPLE_APP" : "prometheus-sample-app:8080" }
   }


### PR DESCRIPTION
## Description
Otel collector had some breaking changes with the new release. 
This is the new ECS config for sending metrics to AMP.
https://github.com/aws-observability/aws-otel-collector/blob/main/examples/ecs/aws-prometheus/ecs-fargate-adot-config.yaml

## Motivation and Context
Fixes the adot config file errors

## How Has This Been Tested?
I tested this config on the CDK version and it worked. It would be great if someone can validate.
