### PR TITLE
Bump ruby from 2.5 to 2.6.7

### DIFF
--- a/application-code/ecsdemo-frontend/Dockerfile
+++ b/application-code/ecsdemo-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # FROM ruby:2.5-slim
-FROM public.ecr.aws/bitnami/ruby:2.5
+FROM public.ecr.aws/bitnami/ruby:2.6.7
 
 COPY Gemfile Gemfile.lock /usr/src/app/
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Description
Bump ruby to 2.6.7. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will make it compatible with the new packages from Dependabot fixes based in this [PR](https://github.com/aws-ia/terraform-aws-ecs-blueprints/pull/76)
## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
